### PR TITLE
Switch from “overlap” to “shift”

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ void cccConfigSetFFTLength(CCCConfig config, unsigned long fft_length);
 // default: 1,024
 // must be a power of 2
 
-void cccConfigSetFFTOverlap(CCCConfig config, unsigned long fft_overlap);
-// default: 1,005
+void cccConfigSetFFTShift(CCCConfig config, unsigned long fft_shift);
+// default: 19
 
 void cccConfigSetWeightByPower(CCCConfig config, bool pow_weight);
 // default: true
@@ -75,7 +75,7 @@ You can also calculate the full spectrogram for a signal in one call. The progra
 struct ConsensusContourSize dim = cccSizeSetup(const CCCSetup setup, const unsigned long signal_len);
 ```
 
-The returned `struct ConsensusContourSize` contains fields `dim.bytes` telling you how many bytes are required for the full spectrogram, as well as `dim.rows` (the number of rows based on the `fft_length` and `fft_overlap`) and the `dim.cols` (equal to `fft_length / 2`).
+The returned `struct ConsensusContourSize` contains fields `dim.bytes` telling you how many bytes are required for the full spectrogram, as well as `dim.rows` (the number of rows based on the `fft_length` and `fft_shift`) and the `dim.cols` (equal to `fft_length / 2`).
 
 Once you allocate an output vector with sufficient space (see `bytes` above), you can calculate the spectrogram all at once:
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ void cccColumn(const CCCSetup setup, const float *signal, float *contour);
 You can also calculate the full spectrogram for a signal in one call. The program provides a `struct ConsensusContourSize` type that contains size information to help in pre-allocating the output memory. To get the required dimensions, call:
 
 ```c
-struct ConsensusContourSize dim = cccSize(const CCCSetup setup, const unsigned long signal_len);
+struct ConsensusContourSize dim = cccSizeSetup(const CCCSetup setup, const unsigned long signal_len);
 ```
 
 The returned `struct ConsensusContourSize` contains fields `dim.bytes` telling you how many bytes are required for the full spectrogram, as well as `dim.rows` (the number of rows based on the `fft_length` and `fft_overlap`) and the `dim.cols` (equal to `fft_length / 2`).

--- a/_consensus_contour.c
+++ b/_consensus_contour.c
@@ -9,7 +9,7 @@ static REAL TYPE(s_two) = 2.0;
 
 struct TYPE(OpaqueCCCConfig) {
     t_len fft_length;
-    t_len fft_overlap;
+    t_len fft_shift;
     
     bool pow_weight;
     
@@ -32,7 +32,7 @@ TYPE(CCCConfig) TYPE(createCCCConfig)() {
     
     // default fft parameters
     ret->fft_length = 1024;
-    ret->fft_overlap = 1005;
+    ret->fft_shift = 19;
     ret->pow_weight = true;
     ret->fs = 44100;
     
@@ -57,8 +57,8 @@ void TYPE(cccConfigSetFFTLength)(TYPE(CCCConfig) config, const t_len fft_length)
     config->fft_length = fft_length;
 }
 
-void TYPE(cccConfigSetFFTOverlap)(TYPE(CCCConfig) config, const t_len fft_overlap) {
-    config->fft_overlap = fft_overlap;
+void TYPE(cccConfigSetFFTShift)(TYPE(CCCConfig) config, const t_len fft_shift) {
+    config->fft_shift = fft_shift;
 }
 
 void TYPE(cccConfigSetWeightByPower)(TYPE(CCCConfig) config, const bool pow_weight) {
@@ -339,7 +339,7 @@ struct ConsensusContourSize TYPE(cccSizeConfig)(const TYPE(CCCConfig) config, co
     }
     
     const t_len ccn = config->fft_length / 2;
-    const t_len ccm = 1 + (signal_len - config->fft_length) / (config->fft_length - config->fft_overlap);
+    const t_len ccm = 1 + (signal_len - config->fft_length) / config->fft_shift;
     
     ret.rows = ccn;
     ret.cols = ccm;
@@ -363,7 +363,7 @@ struct ConsensusContourSize TYPE(cccSizeSetup)(const TYPE(CCCSetup) setup, const
     }
     
     const t_len ccn = setup->config.fft_length / 2;
-    const t_len ccm = 1 + (signal_len - setup->config.fft_length) / (setup->config.fft_length - setup->config.fft_overlap);
+    const t_len ccm = 1 + (signal_len - setup->config.fft_length) / setup->config.fft_shift;
     
     ret.rows = ccn;
     ret.cols = ccm;
@@ -384,7 +384,7 @@ void TYPE(cccBins)(const TYPE(CCCSetup) setup, const struct ConsensusContourSize
     
     if (times) {
         for (t_len j = 0; j < dim.cols; ++j) {
-            times[j] = (REAL)(setup->fft_length_half + j * (setup->config.fft_length - setup->config.fft_overlap)) / setup->config.fs;
+            times[j] = (REAL)(setup->fft_length_half + j * setup->config.fft_shift) / setup->config.fs;
         }
     }
 }
@@ -479,7 +479,7 @@ void TYPE(cccSpectrogram)(const TYPE(CCCSetup) setup, const struct ConsensusCont
     
     /* STEP 2: spectrogram columns */
     for (i = 0; i < dim.cols; ++i) {
-        TYPE(buildColumn)(setup, signal + i * (setup->config.fft_length - setup->config.fft_overlap), consensus_contours + i * setup->fft_length_half);
+        TYPE(buildColumn)(setup, signal + i * setup->config.fft_shift, consensus_contours + i * setup->fft_length_half);
     }
 }
 

--- a/_consensus_contour.c
+++ b/_consensus_contour.c
@@ -28,7 +28,7 @@ TYPE(CCCConfig) TYPE(createCCCConfig)() {
     t_len i;
     
     // allocate memory
-    TYPE(CCCConfig) ret = malloc(sizeof(struct TYPE(OpaqueCCCConfig)));
+    TYPE(CCCConfig) ret = (TYPE(struct OpaqueCCCConfig) *)malloc(sizeof(TYPE(struct OpaqueCCCConfig)));
     
     // default fft parameters
     ret->fft_length = 1024;
@@ -38,14 +38,14 @@ TYPE(CCCConfig) TYPE(createCCCConfig)() {
     
     // default timescales
     ret->num_timescales = 9;
-    ret->timescales = malloc(sizeof(REAL) * ret->num_timescales);
+    ret->timescales = (REAL *)malloc(sizeof(REAL) * ret->num_timescales);
     for (i = 0; i < ret->num_timescales; ++i) {
         ret->timescales[i] = CMATH(0.5) + CMATH(0.2) * (REAL)i;
     }
     
     // default angles
     ret->num_angles = 8;
-    ret->angles = malloc(sizeof(REAL) * ret->num_angles);
+    ret->angles = (REAL *)malloc(sizeof(REAL) * ret->num_angles);
     for (i = 0; i < ret->num_angles; ++i) {
         ret->angles[i] = (REAL)M_PI * (REAL)(2 + i) / (REAL)ret->num_angles;
     }
@@ -75,7 +75,7 @@ void TYPE(cccConfigSetTimescales)(TYPE(CCCConfig) config, const t_len num_timesc
     
     // allocate new timescales
     config->num_timescales = num_timescales;
-    config->timescales = malloc(sizeof(REAL) * config->num_timescales);
+    config->timescales = (REAL *)malloc(sizeof(REAL) * config->num_timescales);
     memcpy(config->timescales, &timescales[0], sizeof(REAL) * config->num_timescales);
 }
 
@@ -85,7 +85,7 @@ void TYPE(cccConfigSetAngles)(TYPE(CCCConfig) config, const t_len num_angles, co
     
     // allocate new timescales
     config->num_angles = num_angles;
-    config->angles = malloc(sizeof(REAL) * config->num_angles);
+    config->angles = (REAL *)malloc(sizeof(REAL) * config->num_angles);
     memcpy(config->angles, &angles[0], sizeof(REAL) * config->num_angles);
 }
 
@@ -126,8 +126,8 @@ static void TYPE(setupCCTimescaleAngle)(struct TYPE(CCTimescaleAngle) *ccta, con
     ccta->mu_imag = CMATH(sin)(angle);
     ccta->grad_x = 0 - CMATH(cos)(angle + (REAL)M_PI_2) / CMATH(2.0);
     ccta->grad_y = CMATH(sin)(angle + (REAL)M_PI_2) / CMATH(2.0);
-    ccta->sign_last = calloc(fft_length_half, sizeof(REAL));
-    ccta->sign_cur = calloc(fft_length_half, sizeof(REAL));
+    ccta->sign_last = (REAL *)calloc(fft_length_half, sizeof(REAL));
+    ccta->sign_cur = (REAL *)calloc(fft_length_half, sizeof(REAL));
 }
 
 static void TYPE(destroyCCTimescaleAngle)(struct TYPE(CCTimescaleAngle) *ccta) {
@@ -228,12 +228,12 @@ TYPE(CCCSetup) TYPE(createCCCSetup)(const TYPE(CCCConfig) config) {
     t_len i, j;
     
     /* allocate memory */
-    TYPE(CCCSetup) ret = malloc(sizeof(struct TYPE(OpaqueCCCSetup)));
+    TYPE(CCCSetup) ret = (TYPE(struct OpaqueCCCSetup) *)malloc(sizeof(TYPE(struct OpaqueCCCSetup)));
     
     /* store configuration, and copy pointers */
     memcpy(&ret->config, config, sizeof(TYPE(struct OpaqueCCCConfig)));
-    ret->config.timescales = allocAndCopy(ret->config.timescales, sizeof(REAL) * ret->config.num_timescales);
-    ret->config.angles = allocAndCopy(ret->config.angles, sizeof(REAL) * ret->config.num_angles);
+    ret->config.timescales = (REAL *)allocAndCopy(ret->config.timescales, sizeof(REAL) * ret->config.num_timescales);
+    ret->config.angles = (REAL *)allocAndCopy(ret->config.angles, sizeof(REAL) * ret->config.num_angles);
     
     /* STEP 1: spectrogram, build windows and fft */
     ret->fft_length_half = ret->config.fft_length / 2;
@@ -243,14 +243,14 @@ TYPE(CCCSetup) TYPE(createCCCSetup)(const TYPE(CCCConfig) config) {
     ret->fft_setup = vDSP(create_fftsetup)(ret->fft_size, kFFTRadix2);
     
     /* allocate window */
-    ret->fft_window = malloc(sizeof(REAL) * ret->config.fft_length * ret->config.num_timescales * 2);
-    ret->signal_windowed = malloc(sizeof(REAL) * ret->config.fft_length * ret->config.num_timescales * 2);
+    ret->fft_window = (REAL *)malloc(sizeof(REAL) * ret->config.fft_length * ret->config.num_timescales * 2);
+    ret->signal_windowed = (REAL *)malloc(sizeof(REAL) * ret->config.fft_length * ret->config.num_timescales * 2);
     
     /* allocate temporary and output */
-    ret->fft_temporary.realp = malloc(sizeof(REAL) * ret->fft_length_half);
-    ret->fft_temporary.imagp = malloc(sizeof(REAL) * ret->fft_length_half);
-    ret->fft_output.realp = malloc(sizeof(REAL) * ret->fft_length_half * ret->config.num_timescales * 2);
-    ret->fft_output.imagp = malloc(sizeof(REAL) * ret->fft_length_half * ret->config.num_timescales * 2);
+    ret->fft_temporary.realp = (REAL *)malloc(sizeof(REAL) * ret->fft_length_half);
+    ret->fft_temporary.imagp = (REAL *)malloc(sizeof(REAL) * ret->fft_length_half);
+    ret->fft_output.realp = (REAL *)malloc(sizeof(REAL) * ret->fft_length_half * ret->config.num_timescales * 2);
+    ret->fft_output.imagp = (REAL *)malloc(sizeof(REAL) * ret->fft_length_half * ret->config.num_timescales * 2);
     
     /* make pointers */
     ret->p_exp = ret->fft_output;
@@ -259,19 +259,19 @@ TYPE(CCCSetup) TYPE(createCCCSetup)(const TYPE(CCCConfig) config) {
     ret->p_ratio = ret->p_der;
     
     /* power array */
-    ret->power = malloc(sizeof(REAL) * ret->fft_length_half * ret->config.num_timescales);
+    ret->power = (REAL *)malloc(sizeof(REAL) * ret->fft_length_half * ret->config.num_timescales);
     
     /* conensus array */
     /* might be able to use singles? */
-    ret->consensus = malloc(sizeof(REAL) * ret->fft_length_half * ret->config.num_timescales * ret->config.num_angles);
-    ret->consensus_cur = malloc(sizeof(REAL) * ret->fft_length_half);
-    ret->consensus_pow = malloc(sizeof(REAL) * ret->fft_length_half);
+    ret->consensus = (REAL *)malloc(sizeof(REAL) * ret->fft_length_half * ret->config.num_timescales * ret->config.num_angles);
+    ret->consensus_cur = (REAL *)malloc(sizeof(REAL) * ret->fft_length_half);
+    ret->consensus_pow = (REAL *)malloc(sizeof(REAL) * ret->fft_length_half);
     
     /* fill window */
     TYPE(fillFftWindow)(ret);
     
     /* setup timescale angle structures */
-    ret->ta = malloc(sizeof(TYPE(struct CCTimescaleAngle)) * ret->config.num_timescales * ret->config.num_angles);
+    ret->ta = (TYPE(struct CCTimescaleAngle) *)malloc(sizeof(TYPE(struct CCTimescaleAngle)) * ret->config.num_timescales * ret->config.num_angles);
     for (i = 0; i < ret->config.num_timescales; ++i) {
         for (j = 0; j < ret->config.num_angles; ++j) {
             TYPE(setupCCTimescaleAngle)(ret->ta + i * ret->config.num_angles + j, ret->fft_length_half, ret->config.timescales[i], ret->config.angles[j]);
@@ -324,7 +324,31 @@ static void TYPE(windowSamples)(const TYPE(CCCSetup) setup, const REAL *signal) 
     }
 }
 
-struct ConsensusContourSize TYPE(cccSize)(const TYPE(CCCSetup) setup, const t_len signal_len) {
+struct ConsensusContourSize TYPE(cccSizeConfig)(const TYPE(CCCConfig) config, const t_len signal_len) {
+    struct ConsensusContourSize ret;
+    
+    // store signal length
+    ret.signal_len = signal_len;
+    
+    // insufficient signal?
+    if (signal_len < config->fft_length) {
+        ret.rows = 0;
+        ret.cols = 0;
+        ret.bytes = 0;
+        return ret;
+    }
+    
+    const t_len ccn = config->fft_length / 2;
+    const t_len ccm = 1 + (signal_len - config->fft_length) / (config->fft_length - config->fft_overlap);
+    
+    ret.rows = ccn;
+    ret.cols = ccm;
+    ret.bytes = sizeof(REAL) * ccn * ccm;
+    
+    return ret;
+}
+
+struct ConsensusContourSize TYPE(cccSizeSetup)(const TYPE(CCCSetup) setup, const t_len signal_len) {
     struct ConsensusContourSize ret;
     
     // store signal length

--- a/ccontour.c
+++ b/ccontour.c
@@ -197,7 +197,7 @@ static void processSingle(const int nlhs, mxArray *plhs[], const int nrhs, const
     destroyCCCConfig(ccc_config);
     
     /* figure out contour size */
-    const struct ConsensusContourSize dim = cccSize(ccc_setup, (unsigned long)sl);
+    const struct ConsensusContourSize dim = cccSizeSetup(ccc_setup, (unsigned long)sl);
     if (dim.rows == 0) {
         destroyCCCSetup(ccc_setup);
         mexErrMsgIdAndTxt("MATLAB:ccc:invalidInput", "Signal vector must be at longer than FFT window.");
@@ -370,7 +370,7 @@ static void processDouble(const int nlhs, mxArray *plhs[], const int nrhs, const
     destroyCCCConfigD(ccc_config);
     
     /* figure out contour size */
-    const struct ConsensusContourSize dim = cccSizeD(ccc_setup, (unsigned long)sl);
+    const struct ConsensusContourSize dim = cccSizeSetupD(ccc_setup, (unsigned long)sl);
     if (dim.rows == 0) {
         destroyCCCSetupD(ccc_setup);
         mexErrMsgIdAndTxt("MATLAB:ccc:invalidInput", "Signal vector must be at longer than FFT window.");

--- a/ccontour.c
+++ b/ccontour.c
@@ -128,7 +128,16 @@ static void processSingle(const int nlhs, mxArray *plhs[], const int nrhs, const
             }
             
             double v = mxGetScalar(prhs[i + 1]);
+            if (v < 1) {
+                mxFree(nm);
+                mexErrMsgIdAndTxt("MATLAB:ccc:invalidInput", "FFT shift must be greater than or equal to 1.");
+            }
+            
             fft_shift = (unsigned long)v;
+        }
+        else if (0 == strcmp(nm, "fft_overlap")) {
+            mxFree(nm);
+            mexErrMsgIdAndTxt("MATLAB:ccc:invalidInput", "The \"fft_overlap\" parameter is no longer supported. Instead, supply \"fft_shift\".");
         }
         else if (0 == strcmp(nm, "pow_weight")) {
             if (!mxIsLogicalScalar(prhs[i + 1])) {
@@ -296,7 +305,16 @@ static void processDouble(const int nlhs, mxArray *plhs[], const int nrhs, const
             }
             
             double v = mxGetScalar(prhs[i + 1]);
+            if (v < 1) {
+                mxFree(nm);
+                mexErrMsgIdAndTxt("MATLAB:ccc:invalidInput", "FFT shift must be greater than or equal to 1.");
+            }
+            
             fft_shift = (unsigned long)v;
+        }
+        else if (0 == strcmp(nm, "fft_overlap")) {
+            mxFree(nm);
+            mexErrMsgIdAndTxt("MATLAB:ccc:invalidInput", "The \"fft_overlap\" parameter is no longer supported. Instead, supply \"fft_shift\".");
         }
         else if (0 == strcmp(nm, "pow_weight")) {
             if (!mxIsLogicalScalar(prhs[i + 1])) {

--- a/ccontour.c
+++ b/ccontour.c
@@ -93,7 +93,7 @@ static void processSingle(const int nlhs, mxArray *plhs[], const int nrhs, const
     
     /* ARGUMENT 3+: configuration */
     unsigned long fft_length = 1024;
-    unsigned long fft_overlap = 1005;
+    unsigned long fft_shift = 19;
     bool pow_weight = true;
     unsigned long num_timescales = 0;
     float *timescales = NULL;
@@ -121,14 +121,14 @@ static void processSingle(const int nlhs, mxArray *plhs[], const int nrhs, const
             
             fft_length = tmp;
         }
-        else if (0 == strcmp(nm, "fft_overlap")) {
+        else if (0 == strcmp(nm, "fft_shift")) {
             if (!testScalar(prhs[i + 1])) {
                 mxFree(nm);
-                mexErrMsgIdAndTxt("MATLAB:ccc:invalidInput", "FFT overlap must be a scalar.");
+                mexErrMsgIdAndTxt("MATLAB:ccc:invalidInput", "FFT shift must be a scalar.");
             }
             
             double v = mxGetScalar(prhs[i + 1]);
-            fft_overlap = (unsigned long)v;
+            fft_shift = (unsigned long)v;
         }
         else if (0 == strcmp(nm, "pow_weight")) {
             if (!mxIsLogicalScalar(prhs[i + 1])) {
@@ -173,17 +173,12 @@ static void processSingle(const int nlhs, mxArray *plhs[], const int nrhs, const
         mxFree(nm);
     }
     
-    // validate
-    if (fft_overlap >= fft_length) {
-        mexErrMsgIdAndTxt("MATLAB:ccc:invalidInput", "FFT overlap must be less than the FFT length.");
-    }
-    
     /* PREPARE */
     /* configuration */
     CCCConfig ccc_config = createCCCConfig();
     cccConfigSetSampleRate(ccc_config, (float)fs);
     cccConfigSetFFTLength(ccc_config, fft_length);
-    cccConfigSetFFTOverlap(ccc_config, fft_overlap);
+    cccConfigSetFFTShift(ccc_config, fft_shift);
     cccConfigSetWeightByPower(ccc_config, pow_weight);
     if (0 < num_timescales) {
         cccConfigSetTimescales(ccc_config, num_timescales, timescales);
@@ -266,7 +261,7 @@ static void processDouble(const int nlhs, mxArray *plhs[], const int nrhs, const
     
     /* ARGUMENT 3+: configuration */
     unsigned long fft_length = 1024;
-    unsigned long fft_overlap = 1005;
+    unsigned long fft_shift = 19;
     bool pow_weight = true;
     unsigned long num_timescales = 0;
     double *timescales = NULL;
@@ -294,14 +289,14 @@ static void processDouble(const int nlhs, mxArray *plhs[], const int nrhs, const
             
             fft_length = tmp;
         }
-        else if (0 == strcmp(nm, "fft_overlap")) {
+        else if (0 == strcmp(nm, "fft_shift")) {
             if (!testScalar(prhs[i + 1])) {
                 mxFree(nm);
-                mexErrMsgIdAndTxt("MATLAB:ccc:invalidInput", "FFT overlap must be a scalar.");
+                mexErrMsgIdAndTxt("MATLAB:ccc:invalidInput", "FFT shift must be a scalar.");
             }
             
             double v = mxGetScalar(prhs[i + 1]);
-            fft_overlap = (unsigned long)v;
+            fft_shift = (unsigned long)v;
         }
         else if (0 == strcmp(nm, "pow_weight")) {
             if (!mxIsLogicalScalar(prhs[i + 1])) {
@@ -346,17 +341,12 @@ static void processDouble(const int nlhs, mxArray *plhs[], const int nrhs, const
         mxFree(nm);
     }
     
-    // validate
-    if (fft_overlap >= fft_length) {
-        mexErrMsgIdAndTxt("MATLAB:ccc:invalidInput", "FFT overlap must be less than the FFT length.");
-    }
-    
     /* PREPARE */
     /* configuration */
     CCCConfigD ccc_config = createCCCConfigD();
     cccConfigSetSampleRateD(ccc_config, fs);
     cccConfigSetFFTLengthD(ccc_config, fft_length);
-    cccConfigSetFFTOverlapD(ccc_config, fft_overlap);
+    cccConfigSetFFTShiftD(ccc_config, fft_shift);
     cccConfigSetWeightByPowerD(ccc_config, pow_weight);
     if (0 < num_timescales) {
         cccConfigSetTimescalesD(ccc_config, num_timescales, timescales);

--- a/ccontour.m
+++ b/ccontour.m
@@ -28,8 +28,8 @@
 %   This determines the number of frequency bins (rows) in the returned
 %   spectogram. This must be a power of two.
 %
-%   CCONTOUR(..., 'fft_overlap', FFT_OVERLAP) is the overlap in the signal
-%   between columns in the returned spectrogram. The default is 1005.
+%   CCONTOUR(..., 'fft_shift', FFT_OVERLAP) is the shift in the signal
+%   between columns in the returned spectrogram. The default is 19.
 %
 %   CCONTOUR(..., 'pow_weight', POW_WEIGHT) allows you to determine
 %   whether the returned image should have contours weighted by their

--- a/compile_ccontour_mex.m
+++ b/compile_ccontour_mex.m
@@ -1,25 +1,18 @@
 function compile_ccontour_mex(varargin)
-%COMPILE_DT_MEX Compile MEX versions of dynamic time warping functions
-%   In addition to MATLAB versions of the dynamic time warping code, this
-%   repository offers MEX versions, which are much preferred. The MEX
-%   versions offer close to a 100x speed benefit and are designed to use
-%   substantially less memory.
+%COMPILE_CCONTOUR_MEX Compile MEX versions of dynamic time warping functions
+%   TODO: write me
 %
-%   The repository includes Mac versions of the MEX files already compiled,
-%   but this function allows compiling the MEX files for other platforms.
-%
-%   If you see warnings about non-MEX implementations when running code
-%   from this repository, call this function once to compile the MEX
-%   functions.
+%   The repository offers pre-compiled (binary) MEX files but this function
+%   allows recompiling the MEX files.
 %
 %   No parameters are required, but you can optionally provide parameters:
 %
-%   COMPILE_DT_MEX('debug', true) turns off optimizations, adds debugging
-%   symbols to the binaries and turns on verbose compilation, all to help
-%   debug issues with the MEX files.
+%   COMPILE_CCONTOUR_MEX('debug', true) turns off optimizations, adds 
+%   debugging symbols to the binaries and turns on verbose compilation, all
+%   to help debug issues with the MEX files.
 %
-%   COMPILE_DT_MEX('warnings', true) turns on all warnings during compile
-%   time (only tested with Clang compiler).
+%   COMPILE_CCONTOUR_MEX('warnings', true) turns on all warnings during 
+%   compile time (only tested with Clang compiler).
 
 %% parameters
 debug = false;

--- a/consensus_contour.h
+++ b/consensus_contour.h
@@ -34,7 +34,8 @@ CCCSetup createCCCSetup(const CCCConfig config);
 void destroyCCCSetup(CCCSetup setup);
 
 /* sizing */
-struct ConsensusContourSize cccSize(const CCCSetup setup, const unsigned long signal_len);
+struct ConsensusContourSize cccSizeConfig(const CCCConfig config, const unsigned long signal_len);
+struct ConsensusContourSize cccSizeSetup(const CCCSetup setup, const unsigned long signal_len);
 
 /* info - can be easily calculated from the config, but convience */
 void cccBins(const CCCSetup setup, const struct ConsensusContourSize dim, float *freqs, float *times);
@@ -62,7 +63,8 @@ CCCSetupD createCCCSetupD(const CCCConfigD config);
 void destroyCCCSetupD(CCCSetupD setup);
 
 /* sizing */
-struct ConsensusContourSize cccSizeD(const CCCSetupD setup, const unsigned long signal_len);
+struct ConsensusContourSize cccSizeConfigD(const CCCConfigD config, const unsigned long signal_len);
+struct ConsensusContourSize cccSizeSetupD(const CCCSetupD setup, const unsigned long signal_len);
 
 /* info - can be easily calculated from the config, but convience */
 void cccBinsD(const CCCSetupD setup, const struct ConsensusContourSize dim, double *freqs, double *times);

--- a/consensus_contour.h
+++ b/consensus_contour.h
@@ -21,7 +21,7 @@ struct ConsensusContourSize
 typedef struct OpaqueCCCConfig *CCCConfig;
 CCCConfig createCCCConfig(void); // creates a default configuration
 void cccConfigSetFFTLength(CCCConfig config, unsigned long fft_length);
-void cccConfigSetFFTOverlap(CCCConfig config, unsigned long fft_overlap);
+void cccConfigSetFFTShift(CCCConfig config, unsigned long fft_shift);
 void cccConfigSetWeightByPower(CCCConfig config, bool pow_weight);
 void cccConfigSetSampleRate(CCCConfig config, float fs);
 void cccConfigSetTimescales(CCCConfig config, unsigned long num_timescales, const float timescales[]);
@@ -50,7 +50,7 @@ void cccSpectrogram(const CCCSetup setup, const struct ConsensusContourSize dim,
 typedef struct OpaqueCCCConfigD *CCCConfigD;
 CCCConfigD createCCCConfigD(void); // creates a default configuration
 void cccConfigSetFFTLengthD(CCCConfigD config, unsigned long fft_length);
-void cccConfigSetFFTOverlapD(CCCConfigD config, unsigned long fft_overlap);
+void cccConfigSetFFTShiftD(CCCConfigD config, unsigned long fft_shift);
 void cccConfigSetWeightByPowerD(CCCConfigD config, bool pow_weight);
 void cccConfigSetSampleRateD(CCCConfigD config, double fs);
 void cccConfigSetTimescalesD(CCCConfigD config, unsigned long num_timescales, const double timescales[]);

--- a/profile.c
+++ b/profile.c
@@ -24,8 +24,8 @@ static void profileSingle(const int iter) {
     CCCSetup ccc_setup = createCCCSetup(ccc_config);
     destroyCCCConfig(ccc_config);
     
-    const struct ConsensusContourSize dim = cccSize(ccc_setup, SIGNAL_LEN);
-    out = calloc(dim.rows * dim.cols, sizeof(float));
+    const struct ConsensusContourSize dim = cccSizeSetup(ccc_setup, SIGNAL_LEN);
+    out = (float *)calloc(dim.rows * dim.cols, sizeof(float));
     
     for (i = 0; i < iter; ++i) {
         for (j = 0; j < SIGNAL_LEN; ++j) {
@@ -60,8 +60,8 @@ static void profileDouble(const int iter) {
     CCCSetupD ccc_setup = createCCCSetupD(ccc_config);
     destroyCCCConfigD(ccc_config);
     
-    const struct ConsensusContourSize dim = cccSizeD(ccc_setup, SIGNAL_LEN);
-    out = calloc(dim.rows * dim.cols, sizeof(double));
+    const struct ConsensusContourSize dim = cccSizeSetupD(ccc_setup, SIGNAL_LEN);
+    out = (double *)calloc(dim.rows * dim.cols, sizeof(double));
     
     for (i = 0; i < iter; ++i) {
         for (j = 0; j < SIGNAL_LEN; ++j) {


### PR DESCRIPTION
Rather than configuring the FFT overlap, configure the FFT shift. This makes the parameter independent of the FFT size, and more readily supports either an overlap or a gap between spectral columns. This changes the configuration API (adding `cccConfigSetFFFTShift` and removing `cccConfigSetFFTOverlap`) and the MATLAB configuration options (adding `fft_shift` and removing `fft_overlap`).